### PR TITLE
fix: it is not possible to override the rendering for lit-view

### DIFF
--- a/hydrofoil-shell.ts
+++ b/hydrofoil-shell.ts
@@ -183,6 +183,13 @@ export class HydrofoilShell extends ResourceScope(LitElement) {
     `
   }
 
+  /**
+   * Renders a lit-view element to render the main model.
+   *
+   * By default uses `hydrofoil-shell` and ignores missing templates.
+   *
+   * @returns {TemplateResult}
+   */
   protected renderMain() {
     return html`
       <lit-view .value="${this.model}" ignore-missing template-scope="hydrofoil-shell"></lit-view>

--- a/hydrofoil-shell.ts
+++ b/hydrofoil-shell.ts
@@ -163,7 +163,7 @@ export class HydrofoilShell extends ResourceScope(LitElement) {
       </section>
 
       <section id="main" ?hidden="${this.state !== 'loaded'}">
-        <lit-view .value="${this.model}" ignore-missing template-scope="hydrofoil-shell"></lit-view>
+        ${this.renderMain()}
       </section>
 
       <section id="error" ?hidden="${this.state !== 'error'}">
@@ -180,6 +180,12 @@ export class HydrofoilShell extends ResourceScope(LitElement) {
   protected renderError() {
     return html`
       <pre>${this.lastError && this.lastError.stack}</pre>
+    `
+  }
+
+  protected renderMain() {
+    return html`
+      <lit-view .value="${this.model}" ignore-missing template-scope="hydrofoil-shell"></lit-view>
     `
   }
 


### PR DESCRIPTION
With this change it will be possible to override what gets rendered in the "loaded" state

```js
class MyShell extends HydrofoilShell {
  renderMain() {
    return html`<!-- code for the main state -->`
  }
}
```